### PR TITLE
[master] Android.mk: Use PRODUCT_PLATFORM_SOD as build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,7 @@
+ifeq ($(PRODUCT_PLATFORM_SOD),true)
+
 LOCAL_PATH := $(call my-dir)
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
+
+endif


### PR DESCRIPTION
Use this build barrier to avoid unnecessary inclusion
during the build for non-Sony devices.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>